### PR TITLE
LoopOptTutorial: Basic loop optimization template [STEP2]

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
@@ -33,6 +33,10 @@ public:
 
 private:
   LoopInfo &LI;
+
+  /// Determines if \p L is a candidate for splitting
+  bool isCandidate(const Loop &L) const;
+
 };
 
 class LoopOptTutorialPass : public PassInfoMixin<LoopOptTutorialPass> {

--- a/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
@@ -70,7 +70,7 @@ PreservedAnalyses LoopOptTutorialPass::run(Loop &L, LoopAnalysisManager &LAM,
   LLVM_DEBUG(dbgs() << "Entering LoopOptTutorialPass::run\n");
   LLVM_DEBUG(dbgs() << "Loop: "; L.dump(); dbgs() << "\n");
 
-  bool Changed = LS(AR.LI).run(L);
+  bool Changed = LoopSplit(AR.LI).run(L);
 
   if (!Changed)
     return PreservedAnalyses::all();

--- a/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
@@ -27,26 +27,28 @@ bool LoopSplit::run(Loop &L) const {
 
   LLVM_DEBUG(dbgs() << "Entering " << __func__ << "\n");
 
-  if (isCandidate(L))
-    LLVM_DEBUG(dbgs() << "Loop " << L.getName()
-                      << " is a candidate for splitting!\n");
-  else
+  if (!isCandidate(L)) {
     LLVM_DEBUG(dbgs() << "Loop " << L.getName()
                       << " is not a candidate for splitting.\n");
+    return false;
+  }
+
+  LLVM_DEBUG(dbgs() << "Loop " << L.getName()
+                    << " is a candidate for splitting!\n");
 
   return false;
 }
 
 bool LoopSplit::isCandidate(const Loop &L) const {
-  // Require loops with preheaders and dedicated exits
+  // Require loops with preheaders and dedicated exits.
   if (!L.isLoopSimplifyForm())
     return false;
 
-  // Since we use cloning to split the loop, it has to be safe to clone
+  // Since we use cloning to split the loop, it has to be safe to clone.
   if (!L.isSafeToClone())
     return false;
 
-  // If the loop has multiple exiting blocks, do not split
+  // If the loop has multiple exiting blocks, do not split.
   if (!L.getExitingBlock())
     return false;
 
@@ -56,7 +58,6 @@ bool LoopSplit::isCandidate(const Loop &L) const {
 
   // Only split innermost loops. Thus, if the loop has any children, it cannot
   // be split.
-  //auto Children = L.getSubLoops();
   if (!L.getSubLoops().empty())
     return false;
 
@@ -66,14 +67,10 @@ bool LoopSplit::isCandidate(const Loop &L) const {
 PreservedAnalyses LoopOptTutorialPass::run(Loop &L, LoopAnalysisManager &LAM,
                                            LoopStandardAnalysisResults &AR,
                                            LPMUpdater &U) {
-  bool Changed = false;
-
   LLVM_DEBUG(dbgs() << "Entering LoopOptTutorialPass::run\n");
   LLVM_DEBUG(dbgs() << "Loop: "; L.dump(); dbgs() << "\n");
 
-  LoopSplit LS(AR.LI);
-
-  Changed = LS.run(L);
+  bool Changed = LS(AR.LI).run(L);
 
   if (!Changed)
     return PreservedAnalyses::all();

--- a/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
@@ -27,9 +27,40 @@ bool LoopSplit::run(Loop &L) const {
 
   LLVM_DEBUG(dbgs() << "Entering " << __func__ << "\n");
 
-  LLVM_DEBUG(dbgs() << "TODO: Need to check if Loop is a valid candidate\n");
+  if (isCandidate(L))
+    LLVM_DEBUG(dbgs() << "Loop " << L.getName()
+                      << " is a candidate for splitting!\n");
+  else
+    LLVM_DEBUG(dbgs() << "Loop " << L.getName()
+                      << " is not a candidate for splitting.\n");
 
   return false;
+}
+
+bool LoopSplit::isCandidate(const Loop &L) const {
+  // Require loops with preheaders and dedicated exits
+  if (!L.isLoopSimplifyForm())
+    return false;
+
+  // Since we use cloning to split the loop, it has to be safe to clone
+  if (!L.isSafeToClone())
+    return false;
+
+  // If the loop has multiple exiting blocks, do not split
+  if (!L.getExitingBlock())
+    return false;
+
+  // If loop has multiple exit blocks, do not split.
+  if (!L.getExitBlock())
+    return false;
+
+  // Only split innermost loops. Thus, if the loop has any children, it cannot
+  // be split.
+  //auto Children = L.getSubLoops();
+  if (!L.getSubLoops().empty())
+    return false;
+
+  return true;
 }
 
 PreservedAnalyses LoopOptTutorialPass::run(Loop &L, LoopAnalysisManager &LAM,


### PR DESCRIPTION
See https://github.com/kitbarton/llvm-project/pull/1 for the first part of the tutorial.

In this second step we add a member function to select candidate loops. We want to avoid transforming loops that do not have a set of required characteristics, and continue processing only loops that have those characteristic. For a more exhaustive example please refer to the Loop Fusion transformation in LLVM.