### PR TITLE
LoopOptTutorial: Basic loop optimization template [STEP4] 

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
@@ -17,9 +17,9 @@
 #define LLVM_TRANSFORMS_SCALAR_LOOPOPTTUTORIAL_H
 
 #include "llvm/Analysis/LoopAnalysisManager.h"
+#include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
-#include "llvm/Analysis/LoopInfo.h"
 
 namespace llvm {
 
@@ -28,6 +28,7 @@ class LPMUpdater;
 
 /// This class splits the innermost loop in a loop nest in the middle.
 class LoopSplit {
+private:
 public:
   LoopSplit(LoopInfo &LI, ScalarEvolution &SE, DominatorTree &DT)
       : LI(LI), SE(SE), DT(DT) {}
@@ -57,20 +58,18 @@ private:
   Instruction *computeSplitPoint(const Loop &L,
                                  Instruction *InsertBefore) const;
 
-
   /// Get the latch comparison instruction of loop \p L.
   ICmpInst *getLatchCmpInst(const Loop &L) const;
 
   /// Update the dominator tree after cloning the loop.
   void updateDominatorTree(const Loop &OrigLoop, const Loop &ClonedLoop,
-                           BasicBlock &InsertBefore,
-                           BasicBlock &Pred,
+                           BasicBlock &InsertBefore, BasicBlock &Pred,
                            ValueToValueMapTy &VMap) const;
 
   // Dump the LLVM IR for function \p F.
   void dumpFunction(const StringRef Msg, const Function &F) const;
 
- private:
+private:
   LoopInfo &LI;
   ScalarEvolution &SE;
   DominatorTree &DT;

--- a/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
@@ -57,7 +57,7 @@ private:
   Instruction *computeSplitPoint(const Loop &L,
                                  Instruction *InsertBefore) const;
 
-  
+
   /// Get the latch comparison instruction of loop \p L.
   ICmpInst *getLatchCmpInst(const Loop &L) const;
 

--- a/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
@@ -28,7 +28,6 @@ class LPMUpdater;
 
 /// This class splits the innermost loop in a loop nest in the middle.
 class LoopSplit {
-private:
 public:
   LoopSplit(LoopInfo &LI, ScalarEvolution &SE, DominatorTree &DT)
       : LI(LI), SE(SE), DT(DT) {}

--- a/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
@@ -17,9 +17,9 @@
 #define LLVM_TRANSFORMS_SCALAR_LOOPOPTTUTORIAL_H
 
 #include "llvm/Analysis/LoopAnalysisManager.h"
-#include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
+#include "llvm/Analysis/LoopInfo.h"
 
 namespace llvm {
 
@@ -57,6 +57,7 @@ private:
   Instruction *computeSplitPoint(const Loop &L,
                                  Instruction *InsertBefore) const;
 
+  
   /// Get the latch comparison instruction of loop \p L.
   ICmpInst *getLatchCmpInst(const Loop &L) const;
 
@@ -68,7 +69,7 @@ private:
   // Dump the LLVM IR for function \p F.
   void dumpFunction(const StringRef Msg, const Function &F) const;
 
-private:
+ private:
   LoopInfo &LI;
   ScalarEvolution &SE;
   DominatorTree &DT;

--- a/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
@@ -156,7 +156,9 @@ Loop *LoopSplit::cloneLoop(Loop &L, BasicBlock &InsertBefore,
 
 
   // Now that we have cloned the loop we need to update the dominator tree.
-  updateDominatorTree(L, *NewLoop, InsertBefore, Pred, VMap);
+  //updateDominatorTree(L, *NewLoop, InsertBefore, Pred, VMap);
+
+  DT.recalculate(*L.getHeader()->getParent());
 
   // Verify that the dominator tree and the loops are correct.
   if (Verify) {

--- a/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
@@ -93,7 +93,7 @@ bool LoopSplit::splitLoopInHalf(Loop &L) const {
 
   // Generate the code that computes the split point.
   Instruction *Split =
-      computeSplitPoint(L, L.getLoopPreheader()->getTerminator());
+    computeSplitPoint(L, L.getLoopPreheader()->getTerminator());
 
   // Split the loop preheader to create an insertion point for the cloned loop.
   BasicBlock *Preheader = L.getLoopPreheader();
@@ -186,12 +186,12 @@ Instruction *LoopSplit::computeSplitPoint(const Loop &L,
 
   Value &IVInitialVal = Bounds->getInitialIVValue();
   Value &IVFinalVal = Bounds->getFinalIVValue();
-  auto *Sub = BinaryOperator::Create(Instruction::Sub, &IVFinalVal,
-                                     &IVInitialVal, "", InsertBefore);
+  auto *Sub =
+    BinaryOperator::Create(Instruction::Sub, &IVFinalVal, &IVInitialVal, "", InsertBefore);
 
   return BinaryOperator::Create(Instruction::UDiv, Sub,
-                                ConstantInt::get(IVFinalVal.getType(), 2), "",
-                                InsertBefore);
+                                ConstantInt::get(IVFinalVal.getType(), 2), 
+                                "", InsertBefore);
 }
 
 ICmpInst *LoopSplit::getLatchCmpInst(const Loop &L) const {
@@ -233,7 +233,6 @@ static Loop *myCloneLoopWithPreheader(
   BasicBlock *OrigPH = OrigLoop->getLoopPreheader();
   assert(OrigPH && "No preheader");
   BasicBlock *NewPH = CloneBasicBlock(OrigPH, VMap, NameSuffix, F);
-
   // To rename the loop PHIs.
   VMap[OrigPH] = NewPH;
   Blocks.push_back(NewPH);

--- a/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
@@ -29,11 +29,6 @@ using namespace llvm;
 #define DEBUG_TYPE "loop-opt-tutorial"
 static const char *VerboseDebug = DEBUG_TYPE "-verbose";
 
-static cl::opt<bool>
-    Verify(DEBUG_TYPE "-verify", cl::Hidden,
-           cl::desc("Turn on DominatorTree and LoopInfo verification"),
-           cl::init(true));
-
 /// Clones a loop \p OrigLoop.  Returns the loop and the blocks in \p
 /// Blocks.
 /// Updates LoopInfo assuming the loop is dominated by block \p LoopDomBB.
@@ -170,16 +165,16 @@ Loop *LoopSplit::cloneLoop(Loop &L, BasicBlock &InsertBefore,
   DTU.flush();
 
   // Verify that the dominator tree and the loops are correct.
-  if (Verify) {
-    assert(DT.verify(DominatorTree::VerificationLevel::Full) &&
-           "Dominator tree is invalid");
-    L.verifyLoop();
-    NewLoop->verifyLoop();
-    if (L.getParentLoop())
-      L.getParentLoop()->verifyLoop();
+#ifndef NDEBUG
+  assert(DT.verify(DominatorTree::VerificationLevel::Full) &&
+         "Dominator tree is invalid");
+  L.verifyLoop();
+  NewLoop->verifyLoop();
+  if (L.getParentLoop())
+    L.getParentLoop()->verifyLoop();
 
-    LI.verify(DT);
-  }
+  LI.verify(DT);
+#endif
 
   return NewLoop;
 }

--- a/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
@@ -190,7 +190,7 @@ Instruction *LoopSplit::computeSplitPoint(const Loop &L,
     BinaryOperator::Create(Instruction::Sub, &IVFinalVal, &IVInitialVal, "", InsertBefore);
 
   return BinaryOperator::Create(Instruction::UDiv, Sub,
-                                ConstantInt::get(IVFinalVal.getType(), 2), 
+                                ConstantInt::get(IVFinalVal.getType(), 2),
                                 "", InsertBefore);
 }
 


### PR DESCRIPTION
For the previous step take a look at #3.

In the previous step we dealt with the code generation portion of our transformation and we showed how to split a candidate loop.  In this step we show how to reflect the LLVM IR changes into the dominator tree data structure. We use the dominator tree updater services to apply the required dominator tree changes. 
