### PR TITLE
LoopOptTutorial: Basic loop optimization template [STEP5]

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
@@ -25,12 +25,15 @@ namespace llvm {
 
 class Loop;
 class LPMUpdater;
+class Statistic;
+class OptimizationRemarkEmitter;
 
 /// This class splits the innermost loop in a loop nest in the middle.
 class LoopSplit {
 public:
-  LoopSplit(LoopInfo &LI, ScalarEvolution &SE, DominatorTree &DT)
-      : LI(LI), SE(SE), DT(DT) {}
+  LoopSplit(LoopInfo &LI, ScalarEvolution &SE, DominatorTree &DT,
+            OptimizationRemarkEmitter &ORE)
+      : LI(LI), SE(SE), DT(DT), ORE(ORE) {}
 
   /// Execute the transformation on the loop nest rooted by \p L.
   bool run(Loop &L) const;
@@ -65,6 +68,15 @@ private:
                            BasicBlock &InsertBefore, BasicBlock &Pred,
                            ValueToValueMapTy &VMap) const;
 
+  /// Report that loop \p L that is not a candidate for splitting.
+  bool reportInvalidCandidate(const Loop &L, Statistic &Stat) const;
+
+  /// Report that loop \p L was successfully split.
+  void reportSuccess(const Loop &L, Statistic &Stat) const;
+
+  /// Report that loop \p L was not successfully split.
+  void reportFailure(const Loop &L, Statistic &Stat) const;
+
   // Dump the LLVM IR for function \p F.
   void dumpFunction(const StringRef Msg, const Function &F) const;
 
@@ -72,6 +84,7 @@ private:
   LoopInfo &LI;
   ScalarEvolution &SE;
   DominatorTree &DT;
+  OptimizationRemarkEmitter &ORE;
 };
 
 class LoopOptTutorialPass : public PassInfoMixin<LoopOptTutorialPass> {

--- a/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopOptTutorial.h
@@ -32,11 +32,11 @@ public:
   LoopSplit(LoopInfo &LI, ScalarEvolution &SE, DominatorTree &DT)
       : LI(LI), SE(SE), DT(DT) {}
 
-  // Execute the transformation on the loop nest rooted by \p L.
+  /// Execute the transformation on the loop nest rooted by \p L.
   bool run(Loop &L) const;
 
 private:
-  /// Determines if \p L is a candidate for splitting
+  /// Determines if \p L is a candidate for splitting.
   bool isCandidate(const Loop &L) const;
 
   /// Split the given loop in the middle by creating a new loop that traverse
@@ -44,7 +44,7 @@ private:
   /// bounds of \p L to traverse the remaining half.
   /// Note: \p L is expected to be the innermost loop in a loop nest or a top
   /// level loop.
-  bool splitLoopInHalf(Loop &L) const;
+  bool splitLoop(Loop &L) const;
 
   /// Clone loop \p L and insert the cloned loop before the basic block \p
   /// InsertBefore, \p Pred is the predecessor of \p L.

--- a/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
@@ -14,9 +14,11 @@
 //===----------------------------------------------------------------------===
 
 #include "llvm/Transforms/Scalar/LoopOptTutorial.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/DomTreeUpdater.h"
 #include "llvm/Analysis/IVDescriptors.h"
 #include "llvm/Analysis/LoopPass.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/IR/Function.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
@@ -28,6 +30,14 @@ using namespace llvm;
 
 #define DEBUG_TYPE "loop-opt-tutorial"
 static const char *VerboseDebug = DEBUG_TYPE "-verbose";
+
+STATISTIC(LoopSplitted, "Loop has been splitted");
+STATISTIC(LoopNotSplitted, "Failed to split the loop");
+STATISTIC(NotInSimplifiedForm, "Loop not in simplified form");
+STATISTIC(UnsafeToClone, "Loop cannot be safely cloned");
+STATISTIC(NotUniqueExitingBlock, "Loop doesn't have a unique exiting block");
+STATISTIC(NotUniqueExitBlock, "Loop doesn't have a unique exit block");
+STATISTIC(NotInnerMostLoop, "Loop is not an innermost loop");
 
 /// Clones a loop \p OrigLoop.  Returns the loop and the blocks in \p
 /// Blocks.
@@ -46,39 +56,45 @@ static Loop *myCloneLoopWithPreheader(
 bool LoopSplit::run(Loop &L) const {
   LLVM_DEBUG(dbgs() << "Entering " << __func__ << "\n");
 
+  // First analyze the loop and prune invalid candidates.
+  if (!isCandidate(L))
+    return false;
+
   if (!isCandidate(L)) {
     LLVM_DEBUG(dbgs() << "Loop " << L.getName()
                       << " is not a candidate for splitting.\n");
     return false;
   }
 
-  LLVM_DEBUG(dbgs() << "Loop " << L.getName()
-                    << " is a candidate for splitting!\n");
+  // Attempt to split the loop and report the result.
+  if (!splitLoop(L))
+    reportFailure(L, LoopNotSplitted);
 
-  return splitLoop(L);
+  reportSuccess(L, LoopSplitted);
+  return true;
 }
 
 bool LoopSplit::isCandidate(const Loop &L) const {
   // Require loops with preheaders and dedicated exits.
   if (!L.isLoopSimplifyForm())
-    return false;
+    return reportInvalidCandidate(L, NotInSimplifiedForm);
 
   // Since we use cloning to split the loop, it has to be safe to clone.
   if (!L.isSafeToClone())
-    return false;
+    return reportInvalidCandidate(L, UnsafeToClone);
 
   // If the loop has multiple exiting blocks, do not split
   if (!L.getExitingBlock())
-    return false;
+    return reportInvalidCandidate(L, NotUniqueExitingBlock);
 
   // If loop has multiple exit blocks, do not split.
   if (!L.getExitBlock())
-    return false;
+    return reportInvalidCandidate(L, NotUniqueExitBlock);
 
   // Only split innermost loops. Thus, if the loop has any children, it cannot
   // be split.
   if (!L.getSubLoops().empty())
-    return false;
+    return reportInvalidCandidate(L, NotInnerMostLoop);
 
   return true;
 }
@@ -203,6 +219,34 @@ ICmpInst *LoopSplit::getLatchCmpInst(const Loop &L) const {
   return nullptr;
 }
 
+bool LoopSplit::reportInvalidCandidate(const Loop &L, Statistic &Stat) const {
+  assert(L.getLoopPreheader() && "Expecting loop with a preheader");
+  ++Stat;
+  ORE.emit(OptimizationRemarkAnalysis(DEBUG_TYPE, Stat.getName(),
+                                      L.getStartLoc(), L.getLoopPreheader())
+           << "[" << L.getLoopPreheader()->getParent()->getName() << "]: "
+           << "Loop is not a candidate for splitting: " << Stat.getDesc());
+  return false;
+}
+
+void LoopSplit::reportSuccess(const Loop &L, Statistic &Stat) const {
+  assert(L.getLoopPreheader() && "Expecting loop with a preheader");
+  ++Stat;
+  ORE.emit(OptimizationRemark(DEBUG_TYPE, Stat.getName(), L.getStartLoc(),
+                              L.getLoopPreheader())
+           << "[" << L.getLoopPreheader()->getParent()->getName()
+           << "]: " << Stat.getDesc());
+}
+
+void LoopSplit::reportFailure(const Loop &L, Statistic &Stat) const {
+  assert(L.getLoopPreheader() && "Expecting loop with a preheader");
+  ++Stat;
+  ORE.emit(OptimizationRemarkMissed(DEBUG_TYPE, Stat.getName(), L.getStartLoc(),
+                                    L.getLoopPreheader())
+           << "[" << L.getLoopPreheader()->getParent()->getName()
+           << "]: " << Stat.getDesc());
+}
+
 void LoopSplit::dumpFunction(const StringRef Msg, const Function &F) const {
   dbgs() << Msg;
   F.dump();
@@ -309,10 +353,19 @@ static Loop *myCloneLoopWithPreheader(
 PreservedAnalyses LoopOptTutorialPass::run(Loop &L, LoopAnalysisManager &LAM,
                                            LoopStandardAnalysisResults &AR,
                                            LPMUpdater &U) {
+  // Retrieve a function analysis manager to get a cached
+  // OptimizationRemarkEmitter.
+  const auto &FAM =
+      LAM.getResult<FunctionAnalysisManagerLoopProxy>(L, AR).getManager();
+  Function *F = L.getHeader()->getParent();
+  auto *ORE = FAM.getCachedResult<OptimizationRemarkEmitterAnalysis>(*F);
+  if (!ORE)
+    report_fatal_error("OptimizationRemarkEmitterAnalysis was not cached");
+
   LLVM_DEBUG(dbgs() << "Entering LoopOptTutorialPass::run\n");
   LLVM_DEBUG(dbgs() << "Loop: "; L.dump(); dbgs() << "\n");
 
-  bool Changed = LoopSplit(AR.LI, AR.SE, AR.DT).run(L);
+  bool Changed = LoopSplit(AR.LI, AR.SE, AR.DT, *ORE).run(L);
 
   if (!Changed)
     return PreservedAnalyses::all();

--- a/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopOptTutorial.cpp
@@ -55,7 +55,7 @@ bool LoopSplit::run(Loop &L) const {
   LLVM_DEBUG(dbgs() << "Loop " << L.getName()
                     << " is a candidate for splitting!\n");
 
-  return splitLoopInHalf(L);
+  return splitLoop(L);
 }
 
 bool LoopSplit::isCandidate(const Loop &L) const {
@@ -83,7 +83,7 @@ bool LoopSplit::isCandidate(const Loop &L) const {
   return true;
 }
 
-bool LoopSplit::splitLoopInHalf(Loop &L) const {
+bool LoopSplit::splitLoop(Loop &L) const {
   assert(L.isLoopSimplifyForm() && "Expecting a loop in simplify form");
   assert(L.isSafeToClone() && "Loop is not safe to be cloned");
   assert(L.getSubLoops().empty() && "Expecting a innermost loop");

--- a/llvm/test/Transforms/LoopOptTutorial/diagnostics.ll
+++ b/llvm/test/Transforms/LoopOptTutorial/diagnostics.ll
@@ -1,0 +1,44 @@
+; RUN: opt -disable-output -passes='require<opt-remark-emit>,loop(rotate,loop-opt-tutorial)' -pass-remarks-analysis=loop-opt-tutorial < %s 2>&1 | FileCheck %s
+
+; CHECK: remark: diagnostic.c:10:10: [multiple_exits]: Loop is not a candidate for splitting: Loop doesn't have a unique exiting block
+define void @multiple_exits(i32* noalias %arg) {
+entry:
+  br label %header
+
+header:
+  %i = phi i64 [ %inci, %latch ], [ 0, %entry ]
+  %exitcond4 = icmp ne i64 %i, 100
+  br i1 %exitcond4, label %body, label %exit
+
+body:
+  %tmp = add nsw i64 %i, -3
+  %tmp8 = add nuw nsw i64 %i, 3
+  %tmp10 = mul nsw i64 %tmp, %tmp8
+  %tmp12 = srem i64 %tmp10, %i
+  %tmp13 = getelementptr inbounds i32, i32* %arg, i64 %i
+  %tmp14 = trunc i64 %tmp12 to i32
+  store i32 %tmp14, i32* %tmp13, align 4
+  %earlyexitcond = icmp eq i32 %tmp14, 70
+  br i1 %exitcond4, label %exit, label %latch, !dbg !8
+
+latch:
+  %inci = add nuw nsw i64 %i, 1
+  br label %header
+
+exit:
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+!llvm.ident = !{!5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 ", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "diagnostic.c", directory: "/tmp")
+!2 = !{}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"PIC Level", i32 2}
+!5 = !{!"clang version 9.0.0 "}
+!6 = distinct !DISubprogram(name: "", scope: !1, file: !1, line: 1, type: !7, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !2)
+!7 = !DISubroutineType(types: !2)
+!8 = !DILocation(line: 10, column: 10, scope: !6)

--- a/llvm/test/Transforms/LoopOptTutorial/loop_nest.ll
+++ b/llvm/test/Transforms/LoopOptTutorial/loop_nest.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -passes='loop(rotate,loop-opt-tutorial)' -debug-only=loop-opt-tutorial < %s 2>&1 | FileCheck %s
+; RUN: opt -S -passes='require<opt-remark-emit>,loop(rotate,loop-opt-tutorial)' < %s 2>&1 | FileCheck %s
 ; REQUIRES: asserts
 ;
 ; Opts: -correlated-propagation -mem2reg -instcombine -loop-simplify -indvars -instnamer
@@ -68,12 +68,12 @@ i_header:
   %exitcond5 = icmp ne i64 %i, 100
   br i1 %exitcond5, label %j_header, label %exit
 
-j_header:       
+j_header:
   %j = phi i64 [ %incj, %j_latch ], [ 0, %i_header ]
   %exitcond = icmp ne i64 %j, 100
   br i1 %exitcond, label %j_body, label %i_latch
 
-j_body:        
+j_body:
   %sub = add nsw i64 %i, -3
   %tmp = add nuw nsw i64 %i, 3
   %mul = mul nsw i64 %sub, %tmp
@@ -87,11 +87,11 @@ j_latch:
   %incj = add nuw nsw i64 %j, 1
   br label %j_header
 
-i_latch:         
+i_latch:
   %inci = add nuw nsw i64 %i, 1
   br label %i_header
 
-exit:         
+exit:
   ret void
 }
 

--- a/llvm/test/Transforms/LoopOptTutorial/simple.ll
+++ b/llvm/test/Transforms/LoopOptTutorial/simple.ll
@@ -1,6 +1,7 @@
-; RUN: opt -S -passes='loop(rotate,loop-opt-tutorial)' < %s 2>&1 | FileCheck %s
+; RUN: opt -S -passes='require<opt-remark-emit>,loop(rotate,loop-opt-tutorial)' < %s 2>&1 | FileCheck %s
+; RUN: opt -disable-output -passes='require<opt-remark-emit>,loop(rotate,loop-opt-tutorial)' -pass-remarks=loop-opt-tutorial < %s 2>&1 | FileCheck --check-prefix=REMARKS %s
+; REMARKS: remark: simple.c:10:10: [dep_free]: Loop has been splitted
 ; REQUIRES: asserts
-
 ; CHECK-LABEL: dep_free
 ; CHECK-LABEL: entry:
 ; CHECK-NEXT:   [[SUB:%[0-9]*]] = sub i64 100, 0
@@ -37,12 +38,12 @@ define void @dep_free(i32* noalias %arg) {
 entry:
   br label %header
 
-header:                                             
+header:
   %i = phi i64 [ %inci, %latch ], [ 0, %entry ]
   %exitcond4 = icmp ne i64 %i, 100
   br i1 %exitcond4, label %body, label %exit
 
-body:                                             
+body:
   %tmp = add nsw i64 %i, -3
   %tmp8 = add nuw nsw i64 %i, 3
   %tmp10 = mul nsw i64 %tmp, %tmp8
@@ -50,12 +51,28 @@ body:
   %tmp13 = getelementptr inbounds i32, i32* %arg, i64 %i
   %tmp14 = trunc i64 %tmp12 to i32
   store i32 %tmp14, i32* %tmp13, align 4
-  br label %latch
+  br label %latch, !dbg !8
 
-latch:                                            
+
+latch:
   %inci = add nuw nsw i64 %i, 1
   br label %header
 
-exit:                                            
+exit:
   ret void
 }
+
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+!llvm.ident = !{!5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 ", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "simple.c", directory: "/tmp")
+!2 = !{}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"PIC Level", i32 2}
+!5 = !{!"clang version 9.0.0 "}
+!6 = distinct !DISubprogram(name: "", scope: !1, file: !1, line: 1, type: !7, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !2)
+!7 = !DISubroutineType(types: !2)
+!8 = !DILocation(line: 10, column: 10, scope: !6)


### PR DESCRIPTION
For the previous step take a look at #4.

Our transformation pass is almost complete. In the previous step we have shown how to update the dominator tree to reflect the LLVM IR changes the transformation did. In this step we introduce an example of how to use the LLVM OptimizationRemarksEmitter (ORE) to report the result of the simple analysis done in step2 (candidate selection) and the result of the transformation. We also use the LLVM statistic services to report the number of loops that were transformed by our pass. 